### PR TITLE
Add support for SYN event detection in libevdev_has_event_code.

### DIFF
--- a/libevdev/libevdev-int.h
+++ b/libevdev/libevdev-int.h
@@ -82,6 +82,7 @@ struct libevdev {
 	int driver_version;
 	unsigned long bits[NLONGS(EV_CNT)];
 	unsigned long props[NLONGS(INPUT_PROP_CNT)];
+	unsigned long syn_bits[NLONGS(SYN_CNT)];
 	unsigned long key_bits[NLONGS(KEY_CNT)];
 	unsigned long rel_bits[NLONGS(REL_CNT)];
 	unsigned long abs_bits[NLONGS(ABS_CNT)];

--- a/libevdev/libevdev-util.h
+++ b/libevdev/libevdev-util.h
@@ -74,6 +74,7 @@ type_to_mask_const(const struct libevdev *dev, unsigned int type, const unsigned
 	int max;
 
 	switch(type) {
+		max_mask(SYN, syn);
 		max_mask(ABS, abs);
 		max_mask(REL, rel);
 		max_mask(KEY, key);

--- a/libevdev/libevdev.c
+++ b/libevdev/libevdev.c
@@ -286,6 +286,10 @@ libevdev_set_fd(struct libevdev* dev, int fd)
 	if (rc < 0 && errno != EINVAL)
 		goto out;
 
+	rc = ioctl(fd, EVIOCGBIT(EV_SYN, sizeof(dev->syn_bits)), dev->syn_bits);
+	if (rc < 0)
+		goto out;
+
 	rc = ioctl(fd, EVIOCGBIT(EV_REL, sizeof(dev->rel_bits)), dev->rel_bits);
 	if (rc < 0)
 		goto out;
@@ -956,9 +960,6 @@ libevdev_has_event_code(const struct libevdev *dev, unsigned int type, unsigned 
 
 	if (!libevdev_has_event_type(dev, type))
 		return 0;
-
-	if (type == EV_SYN)
-		return 1;
 
 	max = type_to_mask_const(dev, type, &mask);
 

--- a/libevdev/make-event-names.py
+++ b/libevdev/make-event-names.py
@@ -159,6 +159,7 @@ def print_mapping_table(bits):
 	print("")
 	print("#ifndef SYN_MAX /* added in 3.12  */")
 	print("#define SYN_MAX 0xf")
+	print("#define SYN_CNT (SYN_MAX+1)")
 	print("#endif")
 	print("")
 


### PR DESCRIPTION
Previously, `libevdev_has_event_code` would always return `1` for any EV_SYN code. This was probably because the `linux/input.h` did not define SYN_MAX and SYN_CNT unlike the other event types. This [seems to have been corrected](http://git.kernel.org/cgit/linux/kernel/git/dtor/input.git/commit/?h=next&id=52764fed5049655926bcecaefd52f0a415ceb105) in 3.12.

I needed to properly detect EV_SYN support in my project, so I made this patch. I'm not very familiar with the source yet, so I may have missed a few spots somewhere, but the patch adds support for EV_SYN code detection in `libevdev_has_event_code()` and tries to be compatible with the existing style.
